### PR TITLE
validate version header in V2 reader

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 asm = "9.7"
 log4j = "2.19.0"
+junit = "5.9.3"
 
 [libraries]
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
@@ -10,3 +11,5 @@ asm_util = { module = "org.ow2.asm:asm-util", version.ref = "asm" }
 
 log4j_api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j_core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
+
+junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }

--- a/unpick-format-utils/build.gradle
+++ b/unpick-format-utils/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    testImplementation(libs.junit)
+}

--- a/unpick-format-utils/src/main/java/daomephsta/unpick/constantmappers/datadriven/parser/v2/UnpickV2Reader.java
+++ b/unpick-format-utils/src/main/java/daomephsta/unpick/constantmappers/datadriven/parser/v2/UnpickV2Reader.java
@@ -104,8 +104,7 @@ public class UnpickV2Reader implements Closeable
 	private void validateVersion(InputStreamReader definitionStream) throws IOException {
 		// only consume chars for the version
 		char[] versionChars = new char [2];
-		definitionStream.read(versionChars);
-		if (versionChars[0] == 'v')
+		if (definitionStream.read(versionChars) == 2 && versionChars[0] == 'v')
 		{
 			switch (versionChars[1])
 			{
@@ -120,7 +119,7 @@ public class UnpickV2Reader implements Closeable
 			}
 		}
 		else
-			throw new UnpickSyntaxException(1, "Missing version");
+			throw new UnpickSyntaxException(1, "Missing or invalid version");
 	}
 
 	private void visitParameterConstantGroupDefinition(Visitor visitor, String[] tokens, int lineNumber)

--- a/unpick-format-utils/src/test/java/daomephsta/unpick/tests/TestV2Reader.java
+++ b/unpick-format-utils/src/test/java/daomephsta/unpick/tests/TestV2Reader.java
@@ -1,0 +1,59 @@
+package daomephsta.unpick.tests;
+
+import daomephsta.unpick.constantmappers.datadriven.parser.UnpickSyntaxException;
+import daomephsta.unpick.constantmappers.datadriven.parser.v2.UnpickV2Reader;
+import daomephsta.unpick.constantmappers.datadriven.parser.v2.UnpickV2Writer;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TestV2Reader {
+	private final Path missingHeader;
+	private final Path validSyntax;
+	private final Path invalidKeyword;
+
+	public TestV2Reader() throws URISyntaxException {
+		Path dir = getResource("/v2_test_files");
+		missingHeader = dir.resolve("missing_header.unpick");
+		validSyntax = dir.resolve("valid_syntax.unpick");
+		invalidKeyword = dir.resolve("invalid_keyword.unpick");
+	}
+
+	private static Path getResource(String name) throws URISyntaxException {
+		return Paths.get(TestV2Reader.class.getResource(name).toURI());
+	}
+
+	@Test
+	void testValidRead() throws IOException {
+		File file = validSyntax.toFile();
+
+		try (UnpickV2Reader reader = new UnpickV2Reader(Files.newInputStream(file.toPath()))) {
+			reader.accept(new UnpickV2Writer());
+		}
+	}
+
+	@Test
+	void testMissingHeader() throws IOException {
+		File file = missingHeader.toFile();
+
+		try (UnpickV2Reader reader = new UnpickV2Reader(Files.newInputStream(file.toPath()))) {
+			assertThrows(UnpickSyntaxException.class, () -> reader.accept(new UnpickV2Writer()));
+		}
+	}
+
+	@Test
+	void testInvalidKeyword() throws IOException {
+		File file = invalidKeyword.toFile();
+
+		try (UnpickV2Reader reader = new UnpickV2Reader(Files.newInputStream(file.toPath()))) {
+			assertThrows(UnpickSyntaxException.class, () -> reader.accept(new UnpickV2Writer()));
+		}
+	}
+}

--- a/unpick-format-utils/src/test/resources/v2_test_files/invalid_keyword.unpick
+++ b/unpick-format-utils/src/test/resources/v2_test_files/invalid_keyword.unpick
@@ -1,0 +1,7 @@
+v2
+
+gaming flag org/quiltmc/Gaming GAMING
+gaming flag org/quiltmc/Gaming NOT_GAMING
+
+target_method org/quiltmc/Gaming getFlag (I)Z
+	param 0 flag

--- a/unpick-format-utils/src/test/resources/v2_test_files/missing_header.unpick
+++ b/unpick-format-utils/src/test/resources/v2_test_files/missing_header.unpick
@@ -1,0 +1,5 @@
+constant flag org/quiltmc/Gaming GAMING
+constant flag org/quiltmc/Gaming NOT_GAMING
+
+target_method org/quiltmc/Gaming getFlag (I)Z
+	param 0 flag

--- a/unpick-format-utils/src/test/resources/v2_test_files/valid_syntax.unpick
+++ b/unpick-format-utils/src/test/resources/v2_test_files/valid_syntax.unpick
@@ -1,0 +1,7 @@
+v2
+
+constant flag org/quiltmc/Gaming GAMING
+constant flag org/quiltmc/Gaming NOT_GAMING
+
+target_method org/quiltmc/Gaming getFlag (I)Z
+	param 0 flag


### PR DESCRIPTION
in QM, if you add an unpick definition and forget the version header it causes a silent failure on unpick -- other definitions work, but yours doesn't. with this change, it will now report an error