### PR TITLE
ensure that version bytes are not lost when using a DDCM

### DIFF
--- a/src/main/java/daomephsta/unpick/impl/constantmappers/datadriven/DataDrivenConstantMapper.java
+++ b/src/main/java/daomephsta/unpick/impl/constantmappers/datadriven/DataDrivenConstantMapper.java
@@ -1,8 +1,13 @@
 package daomephsta.unpick.impl.constantmappers.datadriven;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 
 import daomephsta.unpick.api.IClassResolver;
 import daomephsta.unpick.api.constantresolvers.IConstantResolver;
@@ -36,16 +41,21 @@ public class DataDrivenConstantMapper extends SimpleAbstractConstantMapper
 				//Avoid buffering, so that only the version specifier bytes are consumed
 				byte[] version = new byte [2];
 				mappingSource.read(version);
+
+				// prepend the version to the stream (parsers will expect it to be present)
+				List<InputStream> streams = Arrays.asList(new ByteArrayInputStream(version), mappingSource);
+				InputStream newMappingSource = new SequenceInputStream(Collections.enumeration(streams));
+
 				if (version[0] == 'v')
 				{
 					switch (version[1])
 					{
 					case '1':
-						V1Parser.INSTANCE.parse(mappingSource, constantGroups, targetMethodsBuilder);
+						V1Parser.INSTANCE.parse(newMappingSource, constantGroups, targetMethodsBuilder);
 						break;
 
 					case '2':
-						V2Parser.parse(mappingSource, constantGroups, targetMethodsBuilder);
+						V2Parser.parse(newMappingSource, constantGroups, targetMethodsBuilder);
 						break;
 
 					default :

--- a/src/test/java/daomephsta/unpick/tests/TestDataDrivenConstantMapperParsing.java
+++ b/src/test/java/daomephsta/unpick/tests/TestDataDrivenConstantMapperParsing.java
@@ -1,0 +1,51 @@
+package daomephsta.unpick.tests;
+
+import daomephsta.unpick.api.IClassResolver;
+import daomephsta.unpick.api.constantmappers.ConstantMappers;
+import daomephsta.unpick.api.constantresolvers.ConstantResolvers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TestDataDrivenConstantMapperParsing {
+	private final Path validSyntax;
+
+	public TestDataDrivenConstantMapperParsing() throws URISyntaxException {
+		Path dir = getResource("/v2_test_definitions");
+		validSyntax = dir.resolve("valid_syntax.unpick");
+	}
+
+	private static Path getResource(String name) throws URISyntaxException {
+		return Paths.get(TestDataDrivenConstantMapperParsing.class.getResource(name).toURI());
+	}
+
+	@Test
+	void testDDCMParseV2() throws IOException {
+		File file = validSyntax.toFile();
+
+		try (InputStream stream = Files.newInputStream(file.toPath())) {
+			// once classes begin being resolved, we know we have successfully parsed the definitions
+			assertThrows(IClassResolver.ClassResolutionException.class, () -> ConstantMappers.dataDriven(new IClassResolver() {
+				@Override
+				public ClassReader resolveClassReader(String binaryName) throws ClassResolutionException {
+					throw new ClassResolutionException(binaryName);
+				}
+
+				@Override
+				public ClassNode resolveClassNode(String binaryName) throws ClassResolutionException {
+					throw new ClassResolutionException(binaryName);
+				}
+			}, ConstantResolvers.bytecodeAnalysis(new MethodMockingClassResolver()), stream));
+		}
+	}
+}

--- a/src/test/resources/v2_test_definitions/valid_syntax.unpick
+++ b/src/test/resources/v2_test_definitions/valid_syntax.unpick
@@ -1,0 +1,7 @@
+v2
+
+constant flag org/quiltmc/Gaming GAMING
+constant flag org/quiltmc/Gaming NOT_GAMING
+
+target_method org/quiltmc/Gaming getFlag (I)Z
+	param 0 flag

--- a/unpick-format-utils/src/main/java/daomephsta/unpick/constantmappers/datadriven/parser/v2/UnpickV2Reader.java
+++ b/unpick-format-utils/src/main/java/daomephsta/unpick/constantmappers/datadriven/parser/v2/UnpickV2Reader.java
@@ -120,7 +120,7 @@ public class UnpickV2Reader implements Closeable
 			}
 		}
 		else
-			throw new UnpickSyntaxException(1, "Missing or invalid version (version chars: '" + Arrays.toString(versionChars) + "')");
+			throw new UnpickSyntaxException(1, "Missing or invalid version (version chars: " + Arrays.toString(versionChars) + ")");
 	}
 
 	private void visitParameterConstantGroupDefinition(Visitor visitor, String[] tokens, int lineNumber)

--- a/unpick-format-utils/src/main/java/daomephsta/unpick/constantmappers/datadriven/parser/v2/UnpickV2Reader.java
+++ b/unpick-format-utils/src/main/java/daomephsta/unpick/constantmappers/datadriven/parser/v2/UnpickV2Reader.java
@@ -40,6 +40,7 @@ public class UnpickV2Reader implements Closeable
 	{
 		try(InputStreamReader streamReader = new InputStreamReader(definitionsStream))
 		{
+			visitor.startVisit();
 			validateVersion(streamReader);
 			LineNumberReader reader = new LineNumberReader(streamReader);
 
@@ -49,7 +50,7 @@ public class UnpickV2Reader implements Closeable
 				.filter(s -> !s.isEmpty()) //Discard empty lines & lines that are empty once comments are stripped
 				.map(l -> Arrays.stream(WHITESPACE_SPLITTER.split(l)).filter(s -> !s.isEmpty()).toArray(String[]::new)) //Tokenise lines
 				.iterator();
-			visitor.startVisit();
+
 			while(lineTokensIter.hasNext())
 			{
 				String[] tokens = lineTokensIter.next();
@@ -119,7 +120,7 @@ public class UnpickV2Reader implements Closeable
 			}
 		}
 		else
-			throw new UnpickSyntaxException(1, "Missing or invalid version");
+			throw new UnpickSyntaxException(1, "Missing or invalid version (version chars: '" + Arrays.toString(versionChars) + "')");
 	}
 
 	private void visitParameterConstantGroupDefinition(Visitor visitor, String[] tokens, int lineNumber)


### PR DESCRIPTION
fixes an issue i introduced in #3

though the V2 reader expects a line at the start for the version header, it didn't actually need the version header to be there. unbeknownst to me, the `DataDrivenConstantMapper` would consume those bytes, knowing, unlike me, that the V2 reader didn't expect them anyway. i have decided to give these bytes back to the people

todo:
- [x] introduce a test

notes:
required for https://github.com/QuiltMC/quilt-mappings/pull/659